### PR TITLE
Enable persisting API key to local config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/*.egg-info
 **/__pycache__
 **/build
+**/dist

--- a/src/pydstk/api_sdk/config.py
+++ b/src/pydstk/api_sdk/config.py
@@ -2,10 +2,10 @@ import os
 import json
 
 
-_DEFAULT_WEB_URL = "http://localhost:5731"
+_DEFAULT_WEB_URL = "http://localhost:5173"
 _DEFAULT_API_HOST = "http://localhost:4000/graphql"
-_DEFAULT_CONFIG_DIR_PATH = "~/.dstk"
-_DEFAULT_CONFIG_FILE_NAME = os.path.expanduser("config.json")
+_DEFAULT_CONFIG_DIR_PATH = os.path.expanduser("~/.dstk")
+_DEFAULT_CONFIG_FILE_NAME = os.path.join(_DEFAULT_CONFIG_DIR_PATH, "config.json")
 _DEFAULT_HELP_HEADERS_COLOR = "yellow"
 _DEFAULT_HELP_OPTIONS_COLOR = "green"
 _DEFAULT_USE_CONSOLE_COLORS = True
@@ -14,7 +14,7 @@ _DEFAULT_USE_CONSOLE_COLORS = True
 # Copy-pasted from `login.py` to avoid a circular dependency
 # Can probably be cleaned up later
 def get_api_key(pydstk_dir, config_path):
-    pydstk_dir = os.path.expanduser("~/.pydstk") if pydstk_dir is None else pydstk_dir
+    pydstk_dir = os.path.expanduser("~/.dstk") if pydstk_dir is None else pydstk_dir
     config_path = (
         os.path.join(pydstk_dir, "config.json") if config_path is None else config_path
     )

--- a/src/pydstk/cli/__init__.py
+++ b/src/pydstk/cli/__init__.py
@@ -2,6 +2,8 @@ import click
 import colorama
 from click._compat import get_text_stderr
 
+import pydstk.cli.auth  # noqa: F401
+
 
 def show(self, file=None):
     if file is None:

--- a/src/pydstk/login.py
+++ b/src/pydstk/login.py
@@ -8,11 +8,8 @@ from pydstk.api_sdk.config import config
 logger = CliLogger()
 
 
-def apikey(pydstk_dir, config_path):
-    pydstk_dir = os.path.expanduser("~/.pydstk") if pydstk_dir is None else pydstk_dir
-    config_path = (
-        os.path.join(pydstk_dir, "config.json") if config_path is None else config_path
-    )
+def apikey():
+    config_path = config.CONFIG_FILE_NAME
 
     if os.path.exists(config_path):
         config_data = json.load(open(config_path))
@@ -22,8 +19,9 @@ def apikey(pydstk_dir, config_path):
 
 
 def set_apikey(apikey):
-    pydstk_dir = os.path.expanduser("~/.pydstk")
-    config_path = os.path.join(pydstk_dir, "config.json")
+    pydstk_dir = config.CONFIG_DIR_PATH
+    config_path = config.CONFIG_FILE_NAME
+
     if not os.path.exists(pydstk_dir):
         os.makedirs(pydstk_dir)
     config_data = {}


### PR DESCRIPTION
This fixes a couple nits and exposes the `apiKey` subcommand to allow saving an API key to local storage --- by default, `~/.dtsk/config.json`